### PR TITLE
feat(#998): compose UI at /admin/calendar/compose

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,8 +2,8 @@ import type { NextConfig } from "next";
 import { withSentryConfig } from '@sentry/nextjs';
 
 const nextConfig: NextConfig = {
-  // Enable static export for GitHub Pages deployment
-  output: 'export',
+  // Static export for GitHub Pages — disabled in dev so API routes work
+  ...(process.env.NODE_ENV === 'production' ? { output: 'export' as const } : {}),
 
   // No basePath needed for custom domain deployment
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "next dev --turbopack -p ${PORT:-3002}",
     "prebuild": "node scripts/copy-editorial-calendar.js && node scripts/generate-publish-queue-data.js && node scripts/fetch-linkedin-stats.js",
     "fetch-medium": "node scripts/fetch-blog-posts.js",
     "sync-linkedin": "node scripts/fetch-linkedin-stats.js",

--- a/src/app/admin/calendar/CalendarView.tsx
+++ b/src/app/admin/calendar/CalendarView.tsx
@@ -281,11 +281,19 @@ function KV({ label, children }: { label: string; children: React.ReactNode }) {
   );
 }
 
+function composeSlug(draftPath: string): string {
+  const base = draftPath.split('/').pop() ?? '';
+  return base.endsWith('.md') ? base.slice(0, -3) : base;
+}
+
 function DetailLinks({ entry }: { entry: CalendarEntry }) {
-  const links: { href: string; label: string }[] = [];
-  if (entry.blogURL) links.push({ href: entry.blogURL, label: 'blog' });
-  if (entry.mediumURL) links.push({ href: entry.mediumURL, label: 'Medium' });
-  if (entry.linkedinURL) links.push({ href: entry.linkedinURL, label: 'LinkedIn' });
+  const links: { href: string; label: string; external?: boolean }[] = [];
+  if (entry.draftPath && entry.status !== 'published') {
+    links.push({ href: `/admin/calendar/compose?slug=${encodeURIComponent(composeSlug(entry.draftPath))}`, label: 'Edit draft' });
+  }
+  if (entry.blogURL) links.push({ href: entry.blogURL, label: 'blog', external: true });
+  if (entry.mediumURL) links.push({ href: entry.mediumURL, label: 'Medium', external: true });
+  if (entry.linkedinURL) links.push({ href: entry.linkedinURL, label: 'LinkedIn', external: true });
   if (links.length === 0) return null;
   return (
     <div className="mt-2 flex flex-wrap gap-2 text-xs">
@@ -293,10 +301,9 @@ function DetailLinks({ entry }: { entry: CalendarEntry }) {
         <a
           key={l.label}
           href={l.href}
-          target="_blank"
-          rel="noopener noreferrer"
+          {...(l.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
           className="text-primary-teal-text dark:text-primary-teal hover:underline"
-        >{l.label} ↗</a>
+        >{l.label}{l.external ? ' ↗' : ' →'}</a>
       ))}
     </div>
   );

--- a/src/app/admin/calendar/compose/ComposeApp.tsx
+++ b/src/app/admin/calendar/compose/ComposeApp.tsx
@@ -1,0 +1,295 @@
+'use client';
+
+import { useSearchParams, useRouter } from 'next/navigation';
+import { useState, useEffect, useRef, useCallback } from 'react';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface DraftSummary {
+  slug: string;
+  title: string;
+  status: string;
+  pubDate: string;
+  draftPath: string;
+}
+
+interface DraftDetail {
+  slug: string;
+  title: string;
+  pubDate: string;
+  frontmatter: { image: string; alt: string; caption: string };
+  body: string;
+}
+
+type SaveStatus =
+  | { kind: 'idle' }
+  | { kind: 'unsaved' }
+  | { kind: 'saving' }
+  | { kind: 'saved'; time: string }
+  | { kind: 'error'; message: string };
+
+// ─── List view ───────────────────────────────────────────────────────────────
+
+function ComposeList() {
+  const router = useRouter();
+  const [drafts, setDrafts] = useState<DraftSummary[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch('/api/compose')
+      .then(r => r.ok ? r.json() : Promise.reject(`HTTP ${r.status}`))
+      .then(d => setDrafts(d.drafts))
+      .catch(e => setError(String(e)));
+  }, []);
+
+  if (error) return (
+    <div className="p-4 bg-red-50 dark:bg-red-900/20 rounded border border-red-200 dark:border-red-800 text-red-700 dark:text-red-300 text-sm">
+      Failed to load drafts: {error}
+      <p className="mt-1 text-xs">Is the dev server running? (<code>npm run dev</code>)</p>
+    </div>
+  );
+  if (!drafts) return <p className="text-sm text-gray-500 dark:text-gray-400 animate-pulse">Loading drafts…</p>;
+  if (drafts.length === 0) return <p className="text-sm text-gray-500 dark:text-gray-400 italic">No in-flight drafts found.</p>;
+
+  return (
+    <ul className="space-y-2">
+      {drafts.map(d => (
+        <li key={d.slug}>
+          <button
+            onClick={() => router.push(`/admin/calendar/compose?slug=${encodeURIComponent(d.slug)}`)}
+            className="w-full text-left px-4 py-3 rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-dark-surface hover:border-primary-teal hover:bg-primary-teal/5 dark:hover:bg-primary-teal/10 transition-colors group"
+          >
+            <span className="block text-sm font-semibold text-text-dark dark:text-dark-text group-hover:text-primary-teal-text dark:group-hover:text-primary-teal">
+              {d.title || '(untitled)'}
+            </span>
+            <span className="block text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+              <StatusChip status={d.status} />
+              {d.pubDate && <> · {d.pubDate}</>}
+            </span>
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+// ─── Edit view ────────────────────────────────────────────────────────────────
+
+const AUTOSAVE_MS = 30_000;
+const PLACEHOLDER_RE = /\[[^\]]{1,120}\]/g;
+
+function ComposeEdit({ slug }: { slug: string }) {
+  const router = useRouter();
+  const [draft, setDraft] = useState<DraftDetail | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  // Form field state
+  const [image, setImage] = useState('');
+  const [alt, setAlt] = useState('');
+  const [caption, setCaption] = useState('');
+  const [body, setBody] = useState('');
+
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>({ kind: 'idle' });
+  const [placeholders, setPlaceholders] = useState<string[]>([]);
+
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastSavedRef = useRef<string | null>(null);
+
+  // Load draft on mount
+  useEffect(() => {
+    fetch(`/api/compose?slug=${encodeURIComponent(slug)}`)
+      .then(r => r.ok ? r.json() : Promise.reject(`HTTP ${r.status}`))
+      .then((d: DraftDetail) => {
+        setDraft(d);
+        setImage(d.frontmatter.image);
+        setAlt(d.frontmatter.alt);
+        setCaption(d.frontmatter.caption);
+        setBody(d.body);
+        scanPlaceholders(d.body);
+        lastSavedRef.current = JSON.stringify({ image: d.frontmatter.image, alt: d.frontmatter.alt, caption: d.frontmatter.caption, body: d.body });
+      })
+      .catch(e => setLoadError(String(e)));
+  }, [slug]);
+
+  const getPayload = useCallback(() => ({ image, alt, caption, body }), [image, alt, caption, body]);
+
+  const doSave = useCallback(async () => {
+    const payload = getPayload();
+    const key = JSON.stringify(payload);
+    if (lastSavedRef.current === key) return;
+    setSaveStatus({ kind: 'saving' });
+    try {
+      const res = await fetch(`/api/compose?slug=${encodeURIComponent(slug)}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: key,
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      lastSavedRef.current = key;
+      const t = new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+      setSaveStatus({ kind: 'saved', time: t });
+    } catch (e) {
+      setSaveStatus({ kind: 'error', message: String(e) });
+    }
+  }, [slug, getPayload]);
+
+  const scheduleAutosave = useCallback(() => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    setSaveStatus(s => s.kind === 'saved' ? { kind: 'unsaved' } : s.kind === 'idle' ? { kind: 'unsaved' } : s);
+    timerRef.current = setTimeout(doSave, AUTOSAVE_MS);
+  }, [doSave]);
+
+  function scanPlaceholders(text: string) {
+    setPlaceholders(Array.from(text.matchAll(PLACEHOLDER_RE), m => m[0]));
+  }
+
+  const handleBodyChange = (val: string) => {
+    setBody(val);
+    scanPlaceholders(val);
+    setSaveStatus({ kind: 'unsaved' });
+    scheduleAutosave();
+  };
+
+  const handleFieldChange = (setter: (v: string) => void) => (val: string) => {
+    setter(val);
+    setSaveStatus({ kind: 'unsaved' });
+    scheduleAutosave();
+  };
+
+  // Save on focus leaving the form area
+  const handleFormBlur = useCallback((e: React.FocusEvent<HTMLDivElement>) => {
+    if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      doSave();
+    }
+  }, [doSave]);
+
+  // Cleanup timer on unmount
+  useEffect(() => () => { if (timerRef.current) clearTimeout(timerRef.current); }, []);
+
+  if (loadError) return (
+    <div className="p-4 bg-red-50 dark:bg-red-900/20 rounded border border-red-200 dark:border-red-800 text-red-700 dark:text-red-300 text-sm">
+      {loadError}
+    </div>
+  );
+  if (!draft) return <p className="text-sm text-gray-500 dark:text-gray-400 animate-pulse">Loading draft…</p>;
+
+  return (
+    <div onBlur={handleFormBlur}>
+      <div className="flex items-center justify-between mb-6 flex-wrap gap-2">
+        <div>
+          <p className="text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400 font-medium mb-1">
+            <button onClick={() => router.push('/admin/calendar/compose')} className="hover:text-primary-teal-text dark:hover:text-primary-teal">
+              ← All drafts
+            </button>
+          </p>
+          <h2 className="text-xl font-bold text-text-dark dark:text-dark-text">{draft.title || slug}</h2>
+          {draft.pubDate && <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">Scheduled {draft.pubDate}</p>}
+        </div>
+        <SaveIndicator status={saveStatus} onSave={doSave} />
+      </div>
+
+      {placeholders.length > 0 && (
+        <div className="mb-4 p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700 rounded text-sm text-amber-800 dark:text-amber-300" role="alert" aria-live="polite">
+          <strong>⚠ Placeholder blocks remaining:</strong>
+          <ul className="mt-1 ml-4 list-disc space-y-0.5 text-xs font-mono">
+            {placeholders.map((p, i) => <li key={i}>{p}</li>)}
+          </ul>
+        </div>
+      )}
+
+      <div className="space-y-4">
+        <Field label="Image filename" htmlFor="field-image">
+          <input
+            id="field-image"
+            type="text"
+            value={image}
+            onChange={e => handleFieldChange(setImage)(e.target.value)}
+            className={inputCls}
+          />
+        </Field>
+
+        <Field label="Alt text" htmlFor="field-alt">
+          <input
+            id="field-alt"
+            type="text"
+            value={alt}
+            onChange={e => handleFieldChange(setAlt)(e.target.value)}
+            className={inputCls}
+          />
+        </Field>
+
+        <Field label="Caption (spoken-line text — double quotes added automatically)" htmlFor="field-caption">
+          <input
+            id="field-caption"
+            type="text"
+            value={caption}
+            onChange={e => handleFieldChange(setCaption)(e.target.value)}
+            className={inputCls}
+          />
+        </Field>
+
+        <Field label="Body" htmlFor="field-body">
+          <textarea
+            id="field-body"
+            value={body}
+            onChange={e => handleBodyChange(e.target.value)}
+            rows={40}
+            className={`${inputCls} font-mono text-sm resize-y`}
+          />
+        </Field>
+      </div>
+    </div>
+  );
+}
+
+// ─── Root component ───────────────────────────────────────────────────────────
+
+export function ComposeApp() {
+  const params = useSearchParams();
+  const slug = params.get('slug');
+  return slug ? <ComposeEdit slug={slug} /> : <ComposeList />;
+}
+
+// ─── Shared sub-components ────────────────────────────────────────────────────
+
+const inputCls = [
+  'w-full px-3 py-2 rounded-md border border-gray-300 dark:border-gray-700',
+  'bg-white dark:bg-dark-surface text-text-dark dark:text-dark-text',
+  'focus:outline-none focus:ring-2 focus:ring-primary-teal/50 focus:border-primary-teal',
+  'text-sm',
+].join(' ');
+
+function Field({ label, htmlFor, children }: { label: string; htmlFor: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <label htmlFor={htmlFor} className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+        {label}
+      </label>
+      {children}
+    </div>
+  );
+}
+
+function SaveIndicator({ status, onSave }: { status: SaveStatus; onSave: () => void }) {
+  const base = 'text-xs px-3 py-1.5 rounded-md font-medium';
+  if (status.kind === 'idle') return null;
+  if (status.kind === 'unsaved') return (
+    <button onClick={onSave} className={`${base} bg-amber-100 dark:bg-amber-900/30 text-amber-800 dark:text-amber-300 border border-amber-300 dark:border-amber-700 hover:bg-amber-200`}>
+      Unsaved — save now
+    </button>
+  );
+  if (status.kind === 'saving') return <span className={`${base} bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400`}>Saving…</span>;
+  if (status.kind === 'saved') return <span className={`${base} bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300`}>Saved {status.time}</span>;
+  return <span className={`${base} bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300`}>Save failed: {status.message}</span>;
+}
+
+function StatusChip({ status }: { status: string }) {
+  const s = (status || '').toLowerCase();
+  const color =
+    s === 'queued'  ? 'text-blue-700 dark:text-blue-300' :
+    s === 'ready'   ? 'text-green-700 dark:text-green-300' :
+    s === 'drafted' ? 'text-amber-700 dark:text-amber-300' :
+                      'text-gray-600 dark:text-gray-400';
+  return <span className={color}>{status || 'unset'}</span>;
+}

--- a/src/app/admin/calendar/compose/page.tsx
+++ b/src/app/admin/calendar/compose/page.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from 'next';
+import { Suspense } from 'react';
+import { ComposeApp } from './ComposeApp';
+
+export const metadata: Metadata = {
+  title: 'Compose — pipermorgan.ai admin',
+  robots: { index: false, follow: false, noarchive: true, nosnippet: true },
+};
+
+export default function ComposePage() {
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-dark-bg">
+      <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <header className="mb-8">
+          <p className="text-sm uppercase tracking-wider text-gray-500 dark:text-gray-400 font-medium">
+            Admin · <a href="/admin/calendar/" className="hover:text-primary-teal-text dark:hover:text-primary-teal">Editorial Calendar</a>
+          </p>
+          <h1 className="text-3xl font-bold text-text-dark dark:text-dark-text mt-1">Compose</h1>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">
+            Local editorial tool — works only in dev mode. Autosaves 30 s after last change, and on focus-out.
+          </p>
+        </header>
+
+        <Suspense fallback={<p className="text-sm text-gray-500 dark:text-gray-400 animate-pulse">Loading…</p>}>
+          <ComposeApp />
+        </Suspense>
+      </main>
+    </div>
+  );
+}

--- a/src/app/admin/calendar/compose/page.tsx
+++ b/src/app/admin/calendar/compose/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 export default function ComposePage() {
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-dark-bg">
-      <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+      <main className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         <header className="mb-8">
           <p className="text-sm uppercase tracking-wider text-gray-500 dark:text-gray-400 font-medium">
             Admin · <a href="/admin/calendar/" className="hover:text-primary-teal-text dark:hover:text-primary-teal">Editorial Calendar</a>

--- a/src/lib/editorial/draft.ts
+++ b/src/lib/editorial/draft.ts
@@ -1,0 +1,116 @@
+/**
+ * Parse and write editorial draft markdown files.
+ *
+ * TypeScript port of piper-morgan-product/services/editorial/draft.py.
+ * Supports YAML frontmatter (preferred) and legacy HTML-comment metadata.
+ *
+ * Runs server-side only (Node.js file APIs — never imported in client bundles).
+ */
+
+import fs from 'fs';
+
+export const FRONTMATTER_KEYS = ['image', 'alt', 'caption'] as const;
+export type FrontmatterKey = typeof FRONTMATTER_KEYS[number];
+export type Frontmatter = Record<FrontmatterKey, string>;
+
+function emptyFrontmatter(): Frontmatter {
+  return { image: '', alt: '', caption: '' };
+}
+
+function parseYamlBlock(text: string): { fm: Frontmatter; body: string } | null {
+  if (!text.startsWith('---')) return null;
+  const lines = text.split('\n');
+  if (lines[0].trim() !== '---') return null;
+
+  let closeIdx = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === '---') { closeIdx = i; break; }
+  }
+  if (closeIdx === -1) return null;
+
+  const fm = emptyFrontmatter();
+  for (const raw of lines.slice(1, closeIdx)) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    const colonIdx = line.indexOf(':');
+    if (colonIdx === -1) continue;
+    const key = line.slice(0, colonIdx).trim().toLowerCase();
+    let value = line.slice(colonIdx + 1).trim();
+    if (value.startsWith("'") && value.endsWith("'") && value.length >= 2) {
+      value = value.slice(1, -1).replace(/''/g, "'");
+    } else if (value.startsWith('"') && value.endsWith('"') && value.length >= 2) {
+      value = value.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+    }
+    if ((FRONTMATTER_KEYS as readonly string[]).includes(key)) {
+      fm[key as FrontmatterKey] = value;
+    }
+  }
+
+  let bodyLines = lines.slice(closeIdx + 1);
+  if (bodyLines[0]?.trim() === '') bodyLines = bodyLines.slice(1);
+  return { fm, body: bodyLines.join('\n') };
+}
+
+const LEGACY_PATTERNS: Record<FrontmatterKey, RegExp> = {
+  image:   /<!--\s*image:\s*(.+?)\s*-->/i,
+  alt:     /<!--\s*alt:\s*(.+?)\s*-->/i,
+  caption: /<!--\s*caption:\s*(.+?)\s*-->/i,
+};
+
+function parseLegacyComments(text: string): Frontmatter {
+  const fm = emptyFrontmatter();
+  for (const key of FRONTMATTER_KEYS) {
+    const m = text.match(LEGACY_PATTERNS[key]);
+    if (m) {
+      let v = m[1].trim();
+      if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) {
+        v = v.slice(1, -1);
+      }
+      fm[key] = v;
+    }
+  }
+  return fm;
+}
+
+export function parseDraft(filePath: string): { frontmatter: Frontmatter; body: string } {
+  const text = fs.readFileSync(filePath, 'utf-8');
+  const yaml = parseYamlBlock(text);
+  if (yaml) return { frontmatter: yaml.fm, body: yaml.body };
+  return { frontmatter: parseLegacyComments(text), body: text };
+}
+
+function yamlSingleQuote(value: string): string {
+  return "'" + value.replace(/'/g, "''") + "'";
+}
+
+export function writeDraft(filePath: string, frontmatter: Frontmatter, body: string): void {
+  const lines = ['---'];
+  for (const key of FRONTMATTER_KEYS) {
+    lines.push(`${key}: ${yamlSingleQuote(frontmatter[key] ?? '')}`);
+  }
+  lines.push('---', '');
+  let content = lines.join('\n') + body;
+  if (!content.endsWith('\n')) content += '\n';
+
+  const tmp = filePath + '.tmp';
+  try {
+    fs.writeFileSync(tmp, content, 'utf-8');
+    fs.renameSync(tmp, filePath);
+  } catch (e) {
+    try { fs.unlinkSync(tmp); } catch { /* ignore cleanup error */ }
+    throw e;
+  }
+}
+
+/** Strip the spoken-line `"..."` wrapper from a caption for UI display. */
+export function stripCaptionQuotes(caption: string): string {
+  const v = caption.trim();
+  if (v.startsWith('"') && v.endsWith('"') && v.length >= 2) return v.slice(1, -1);
+  return v;
+}
+
+/** Add the spoken-line `"..."` wrapper to a caption before storage. */
+export function wrapCaptionQuotes(caption: string): string {
+  if (!caption) return caption;
+  return `"${caption}"`;
+}

--- a/src/pages/api/compose.ts
+++ b/src/pages/api/compose.ts
@@ -1,0 +1,98 @@
+/**
+ * Compose UI API — list, read, and save editorial drafts.
+ *
+ * Pages Router API route: excluded from `next export` static output without
+ * build errors. Works only in `next dev` (local editorial tool only).
+ *
+ * GET  /api/compose         → list non-published drafts
+ * GET  /api/compose?slug=x  → read draft content + frontmatter
+ * POST /api/compose?slug=x  → save draft (body: { image, alt, caption, body })
+ *
+ * Drafts live in piper-morgan-product/. Set PIPER_PRODUCT_ROOT to override
+ * the default sibling-directory resolution.
+ */
+
+import type { NextApiRequest, NextApiResponse } from 'next';
+import path from 'path';
+import fs from 'fs';
+import { loadCalendar } from '@/lib/editorial-calendar';
+import { parseDraft, writeDraft, stripCaptionQuotes, wrapCaptionQuotes, Frontmatter } from '@/lib/editorial/draft';
+
+const PRODUCT_ROOT = process.env.PIPER_PRODUCT_ROOT
+  || path.resolve(process.cwd(), '..', 'piper-morgan-product');
+
+const DONE_STATUSES = new Set(['published']);
+
+function slugFromDraftPath(draftPath: string): string {
+  return path.basename(draftPath, '.md');
+}
+
+function resolveAbsPath(draftPath: string): string {
+  return path.join(PRODUCT_ROOT, draftPath);
+}
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const slug = typeof req.query.slug === 'string' ? req.query.slug : null;
+
+  if (req.method === 'GET' && !slug) {
+    const entries = loadCalendar().filter(
+      e => e.draftPath && !DONE_STATUSES.has((e.status || '').toLowerCase()),
+    );
+    const drafts = entries.map(e => ({
+      slug: slugFromDraftPath(e.draftPath),
+      title: e.title,
+      status: e.status,
+      pubDate: e.pubDate,
+      draftPath: e.draftPath,
+    }));
+    return res.status(200).json({ drafts });
+  }
+
+  if (req.method === 'GET' && slug) {
+    const entry = loadCalendar().find(
+      e => e.draftPath && slugFromDraftPath(e.draftPath) === slug,
+    );
+    if (!entry) return res.status(404).json({ error: `Draft not found: ${slug}` });
+
+    const absPath = resolveAbsPath(entry.draftPath);
+    if (!fs.existsSync(absPath)) {
+      return res.status(404).json({ error: `Draft file missing on disk: ${entry.draftPath}` });
+    }
+    try {
+      const { frontmatter, body } = parseDraft(absPath);
+      return res.status(200).json({
+        slug,
+        title: entry.title,
+        pubDate: entry.pubDate,
+        frontmatter: { ...frontmatter, caption: stripCaptionQuotes(frontmatter.caption) },
+        body,
+      });
+    } catch (e) {
+      return res.status(500).json({ error: String(e) });
+    }
+  }
+
+  if (req.method === 'POST' && slug) {
+    const { image = '', alt = '', caption = '', body = '' } = (req.body ?? {}) as {
+      image?: string; alt?: string; caption?: string; body?: string;
+    };
+    const entry = loadCalendar().find(
+      e => e.draftPath && slugFromDraftPath(e.draftPath) === slug,
+    );
+    if (!entry) return res.status(404).json({ error: `Draft not found: ${slug}` });
+
+    const absPath = resolveAbsPath(entry.draftPath);
+    if (!fs.existsSync(absPath)) {
+      return res.status(404).json({ error: `Draft file missing on disk: ${entry.draftPath}` });
+    }
+    const frontmatter: Frontmatter = { image, alt, caption: wrapCaptionQuotes(caption) };
+    try {
+      writeDraft(absPath, frontmatter, body);
+      return res.status(200).json({ saved: true, slug });
+    } catch (e) {
+      return res.status(500).json({ error: String(e) });
+    }
+  }
+
+  return res.status(405).json({ error: 'Method not allowed' });
+}


### PR DESCRIPTION
## Summary

- Migrates the compose/edit UI from the FastAPI product app to the Next.js website, where it always belonged (spec correction)
- New page: `/admin/calendar/compose/` — list non-published drafts → click to edit frontmatter + body + autosave
- API: `src/pages/api/compose.ts` (Pages Router, excluded from static export — dev-only tool)
- Editorial calendar now shows **"Edit draft →"** links for non-published posts with a `draftPath`

## Key files

- `src/pages/api/compose.ts` — list, read, save drafts via YAML frontmatter
- `src/lib/editorial/draft.ts` — TypeScript port of `draft.py` (parse/write/atomic rename)
- `src/app/admin/calendar/compose/` — `page.tsx` + `ComposeApp.tsx` client component
- `src/app/admin/calendar/CalendarView.tsx` — added `composeSlug()` + "Edit draft →" link

## Behaviour in production

The compose page renders with a clear "dev mode only" message in production (API routes are excluded from static export). The "Edit draft →" link on the calendar is present but leads to this graceful degradation page on pipermorgan.ai.

## Test plan

- [x] Build passes (`npm run build`) with no errors
- [x] Dev server runs on `:3002` via `npm run dev`
- [x] List view loads non-published drafts from editorial calendar
- [x] Edit view loads draft frontmatter + body, autosaves on blur/30s timer
- [x] "Edit draft →" links visible on calendar detail panel for non-published posts
- [x] PM test-pass: editing Tuesday post via compose UI (2026-06-23)

🤖 Generated with [Claude Code](https://claude.com/claude-code)